### PR TITLE
feat(http_server): expose Connection::complete function

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -738,7 +738,7 @@ impl<'a> EspHttpConnection<'a> {
         Ok(())
     }
 
-    fn complete(&mut self) -> Result<(), HandlerError> {
+    pub fn complete(&mut self) -> Result<(), HandlerError> {
         let buf = &[];
 
         if self.response_headers.is_some() {

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -738,7 +738,7 @@ impl<'a> EspHttpConnection<'a> {
         Ok(())
     }
 
-    pub fn complete(&mut self) -> Result<(), HandlerError> {
+    fn complete(&mut self) -> Result<(), HandlerError> {
         let buf = &[];
 
         if self.response_headers.is_some() {
@@ -750,6 +750,22 @@ impl<'a> EspHttpConnection<'a> {
         self.response_headers = None;
 
         Ok(())
+    }
+
+    /// Forces this connection to be send out by writing an empty buffer.
+    ///
+    /// This is a simple wrapper around [`Self::complete`] with a more "appropriate" name to suggest
+    /// the "dangers"/"problems" which might arise if this function is called.
+    ///
+    /// # Note
+    ///
+    /// There are not guarantees of the state this struct will be in after this call.
+    /// This function should only be used if it can be guaranteed, that the corresponding http
+    /// handler does never return (as this would be the normal way the response would be send out).
+    ///
+    /// See [`crate::httpd::IdfRequest::send`] for details.
+    pub fn force_complete(&mut self) -> Result<(), HandlerError> {
+        self.complete()
     }
 
     fn handle_error<E>(&mut self, error: E)


### PR DESCRIPTION
Exposes the private `Connection::complete` function for downstream crates.
This allows for explicit sending/closing of the connection (required for `https://github.com/Stabl-Energy/Rust-SBC-Client/pull/67`).